### PR TITLE
enable course announcements by top-level category

### DIFF
--- a/lang/de/local_course_announcement.php
+++ b/lang/de/local_course_announcement.php
@@ -25,7 +25,10 @@
 defined('MOODLE_INTERNAL') || die();
 
 $string['pluginname'] = 'Kurs-Ank&uuml;ndigung';
+$string['setting_category'] = 'Category Announcements';
+$string['setting_category_info'] = 'Enable course announcements by category';
 $string['setting_message'] = 'Ank&uuml;ndigungstext';
 $string['setting_message_info'] = 'Dieser Text wird vor jeglichem Kursinhalt angezeigt.';
+$string['setting_catmessage_info'] = 'This text will be shown on top of every course within this category.';
 $string['setting_visible'] = 'Sichtbar';
 $string['setting_visible_info'] = 'Ank&uuml;ndigungen ein-/ausschalten';

--- a/lang/en/local_course_announcement.php
+++ b/lang/en/local_course_announcement.php
@@ -25,7 +25,10 @@
 defined('MOODLE_INTERNAL') || die();
 
 $string['pluginname'] = 'Course Announcement';
+$string['setting_category'] = 'Category Announcements';
+$string['setting_category_info'] = 'Enable course announcements by category';
 $string['setting_message'] = 'Announcement message';
 $string['setting_message_info'] = 'This text will be shown on top of every course main content.';
+$string['setting_catmessage_info'] = 'This text will be shown on top of every course within this category.';
 $string['setting_visible'] = 'Visible';
 $string['setting_visible_info'] = 'Turn announcement on/off';

--- a/lib.php
+++ b/lib.php
@@ -23,26 +23,57 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
+include_once "toolbox.php";
 
 function local_course_announcement_notification () {
-    global $COURSE, $SITE;
+    global $COURSE, $SITE, $PAGE;
 
     $site = isset($SITE) ? $SITE : get_site();
+	$path = explode("/", $PAGE->category->path);
+	$coursecat = $path[1];
+        $coursecats = get_categories_list();
+
     if (isset($COURSE) && $COURSE->id != $site->id) {
         $config = get_config("local_course_announcement");
-        if ($config->visible) {
-            //use context_course rather then context_system because of caching
-            $options = array("context" => context_course::instance($site->id), "trusted" => true, "para" => false);
-            $message = format_text($config->message, FORMAT_MOODLE, $options);
-            \core\notification::add($message, \core\output\notification::NOTIFY_INFO);
-            echo \html_writer::script("(function() {" .
-                                      "var notificationHolder = document.getElementById('user-notifications');" .
-                                      "if (!notificationHolder) { return; }" .
-                                      "notificationHolder.className += ' courseannouncement'" .
-                                      "})();"
-            );
-        }
-    }
 
-    return true;
+
+	if ($config->categories) {
+	    //category announcements enabled, display each category instead of global course announcement
+				$name = 'coursecatmessage'.$coursecat;
+				$visname = 'setting_visible'.$coursecat;
+				$catmessage = $config->$name;
+				$catvisible = $config->$visname;
+
+
+			    if ($catmessage != "" && $catvisible==true) {
+				$options = array("context" => context_course::instance($site->id), "trusted" => true, "para" => false);
+	                        $message = format_text($catmessage, FORMAT_MOODLE, $options);
+        	                \core\notification::add($message, \core\output\notification::NOTIFY_INFO);
+                	        echo \html_writer::script("(function() {" .
+                                             "var notificationHolder = document.getElementById('user-notifications');" .
+                                              "if (!notificationHolder) { return; }" .
+                                              "notificationHolder.className += ' courseannouncement'" .
+                                               "})();"
+                                                );
+
+			    }
+
+
+	} else {
+			if ($config->visible) {
+        	    	//use context_course rather then context_system because of caching
+           	 	$options = array("context" => context_course::instance($site->id), "trusted" => true, "para" => false);
+           	 	$message = format_text($config->message, FORMAT_MOODLE, $options);
+           	 	\core\notification::add($message, \core\output\notification::NOTIFY_INFO);
+            	 	echo \html_writer::script("(function() {" .
+                 	                     "var notificationHolder = document.getElementById('user-notifications');" .
+                        	              "if (!notificationHolder) { return; }" .
+                                	      "notificationHolder.className += ' courseannouncement'" .
+                               		       "})();"
+            					);
+        		}
+   	}
+    }
+	return true;
 }
+

--- a/settings.php
+++ b/settings.php
@@ -23,17 +23,72 @@
  */
 
 defined('MOODLE_INTERNAL') || die();
+include_once "toolbox.php";
 
 if ($ADMIN->locate("localplugins")) {
     $tmp = new admin_settingpage("course_announcement", get_string("pluginname", "local_course_announcement"));
-    $tmp->add(new admin_setting_confightmleditor("local_course_announcement/message",
+
+    //Toggle for category level course announcements
+    $tmp->add(new admin_setting_configcheckbox("local_course_announcement/categories",
+                                               get_string("setting_category", "local_course_announcement"),
+                                               get_string("setting_category_info", "local_course_announcement"),
+                                               false));
+
+   //check category setting and build page appropriately
+   if (get_config("local_course_announcement", "categories")) {
+
+	// Get all category IDs and their names.  Borrowed with thanks from theme_essential.
+            $coursecats = get_categories_list();
+
+    // Iterate through catagories and create settings.
+      foreach ($coursecats as $key => $value) {
+	if ($value->depth == 1) {
+		$namepath = join(' / ', $value->namechunks);
+		$announcestring = get_string("setting_message", "local_course_announcement");
+		$announcedesc = get_string("setting_catmessage_info", "local_course_announcement");
+		$catvisible = get_string("setting_visible", "local_course_announcement");
+
+		//Site Wide Announcement
+		$tmp->add(new admin_setting_confightmleditor("local_course_announcement/message",
                                                  get_string("setting_message", "local_course_announcement"),
                                                  get_string("setting_message_info", "local_course_announcement"),
                                                  ""));
-    $tmp->add(new admin_setting_configcheckbox("local_course_announcement/visible",
+       		$tmp->add(new admin_setting_configcheckbox("local_course_announcement/visible",
                                                get_string("setting_visible", "local_course_announcement"),
                                                get_string("setting_visible_info", "local_course_announcement"),
                                                false));
 
-    $ADMIN->add("localplugins", $tmp);
+
+		//Build category announcement settings
+		$name = "local_course_announcement/coursecatmessage";
+		$title = $namepath." ".$announcestring;
+		$description = get_string("setting_catmessage_info", "local_course_announcement", array("category" => $namepath));
+		$default = '';
+        	$setting = new admin_setting_confightmleditor($name.$key, $title, $description, $default);
+		$tmp->add($setting);
+
+		//Build catogory announcement toggle settings
+		$name = "local_course_announcement/setting_visible";
+                $title = $namepath." ".$catvisible;
+                $description = get_string("setting_visible_info", "local_course_announcement", array("category" => $namepath));
+		$default = false;
+                $setting = new admin_setting_configcheckbox($name.$key, $title, $description, $default);
+                $tmp->add($setting);
+	}
+     }
+
+   $ADMIN->add("localplugins", $tmp);
+
+   } else {
+       $tmp->add(new admin_setting_confightmleditor("local_course_announcement/message",
+                                                 get_string("setting_message", "local_course_announcement"),
+                                                 get_string("setting_message_info", "local_course_announcement"),
+                                                 ""));
+       $tmp->add(new admin_setting_configcheckbox("local_course_announcement/visible",
+                                               get_string("setting_visible", "local_course_announcement"),
+                                               get_string("setting_visible_info", "local_course_announcement"),
+                                               false));
+
+       $ADMIN->add("localplugins", $tmp);
+   }
 }

--- a/toolbox.php
+++ b/toolbox.php
@@ -1,0 +1,52 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * The following code was copied from the Essential theme toolbox. Credit to Gareth J Barnard, et al.
+ *
+ * @package     course_announcement
+ * @copyright   2016 Gareth J Barnard
+ * @copyright   2015 Gareth J Barnard
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+
+defined('MOODLE_INTERNAL') || die;
+
+function get_categories_list() {
+	$catlist = '';
+        if (empty($catlist)) {
+            global $DB;
+            $catlist = $DB->get_records('course_categories', null, 'sortorder', 'id, name, depth, path');
+
+            foreach ($catlist as $category) {
+                $category->parents = array();
+                if ($category->depth > 1 ) {
+                    $path = preg_split('|/|', $category->path, -1, PREG_SPLIT_NO_EMPTY);
+                    $category->namechunks = array();
+                    foreach ($path as $parentid) {
+                        $category->namechunks[] = $catlist[$parentid]->name;
+                        $category->parents[] = $parentid;
+		    }
+                    $category->parents = array_reverse($category->parents);
+                } else {
+                    $category->namechunks = array($category->name);
+                }
+            }
+        }
+
+        return $catlist;
+    }


### PR DESCRIPTION
The change enables a toggle in settings that iterates through level 1 categories.  Users can then define messages by category which show only on courses within that category.  At our institution our level-1 categories correspond to programmes, so this ability comes in quite useful when announcements specific to a particular programme need to be made.